### PR TITLE
Fixed NavBar that was stuck to the top

### DIFF
--- a/client/src/css/NavBar.css
+++ b/client/src/css/NavBar.css
@@ -1,9 +1,14 @@
 .nav {
   width: 100vw;
-  height: 10vh;
-  /* padding: 2vh 0; */
+  height: 16vh;
+  min-height: 90px;
+  padding: 1vh 0;
   display: flex;
   justify-content: center;
+  overflow: hidden;
+  width: 100%;
+  bottom: 0;
+  position: fixed;
 }
 
 .NavBar-item {

--- a/client/src/css/NavBar.css
+++ b/client/src/css/NavBar.css
@@ -12,13 +12,15 @@
 }
 
 .NavBar-item {
-  height: 10vh;
-  width: 10vw;
-  padding: 1vh 0;
+  display: block;
+  float: left;
+  width: 20%;
   text-decoration: none;
 }
 
 .NavBar-link {
+  display: block;
+  text-align: center;
   text-transform: uppercase;
 }
 


### PR DESCRIPTION
* Addresses #38 
* NavBar is now sticky to the bottom and responsive to small images.
* NavBar Items are now evenly spaced.
* __Note:__
  * Did not include extra spacing under the icons, shown in [here](https://github.com/COVID-19-electronic-health-system/Corona-tracker/blob/master/design/wireframes/CORONATRACKER%20UI%20-%20Login%20Screen.png)
  * Also, icons cover the whole span instead of being slightly more padded inward

## NavBar is sticky.
![sticky](https://user-images.githubusercontent.com/34604336/76818313-b0354000-67db-11ea-8c47-253ba20110de.gif)

## NavBar is responsive.

![responsive](https://user-images.githubusercontent.com/34604336/76818138-2e451700-67db-11ea-8c92-8f71fbe837d3.gif)
