### PR TITLE
Setup codebase to access QA environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ And EHR is too ambitious in scope. However [@BrianHHough took down some great no
 
 ## Install, Build and Run Locally (For OSX, Windows Documentation Coming Soon)
 
+### Run Locally
+
 ### Prerequisites
 To run locally, you'll need to have MongoDB installed locally. Follow [this](https://docs.mongodb.com/manual/tutorial/install-mongodb-on-os-x/) guide if you don't have it already
 - Once you have MongoDB installed, start MongoDB, create a new database and create a user with admin privileges:
@@ -33,6 +35,17 @@ You'll also need `radiks-server`, which you can install simply with `npm install
 4. Ensure MongoDB is running (see Prerequisites)
 5. `radiks-server` - start the local radiks server
 6. `npm run start` - run the application locally
+
+### Run in (UNSTABLE) QA Environment
+
+### Installation and run steps
+1. Clone this repo `git clone https://github.com/COVID-19-electronic-health-system/Corona-tracker`
+2. `cd Corona-tracker/client`
+3. `npm i`
+5. Create a new file, `.env`
+6. Message @somemoosery for access to the URL to hit QA endpoint
+6. In `.env`, write and save `REACT_APP_QA_URL: <THE-URL-@SOMEMOOSERY-SENDS-YOU>`
+7. `npm run start` - run the application locally
 
 ## TL;DR FAQ
 A high level basic case for the project. 

--- a/client/.gitignore
+++ b/client/.gitignore
@@ -13,6 +13,7 @@
 
 # misc
 .DS_Store
+.env
 .env.local
 .env.development.local
 .env.test.local

--- a/client/src/models/patient.js
+++ b/client/src/models/patient.js
@@ -1,0 +1,9 @@
+import { Model } from 'radiks';
+
+export default class Patient extends Model {
+    static className = 'Patient';
+    static schema = { // all fields are encrypted by default
+        doctor: String,
+        location: Array,
+    }
+};


### PR DESCRIPTION
[Ticket](https://github.com/COVID-19-electronic-health-system/Corona-tracker/issues/48)

I've managed to set up a (hopefully) working very simple QA database that we can all access and interact with the same data. 

<img width="604" alt="Screen Shot 2020-03-18 at 9 07 43 PM" src="https://user-images.githubusercontent.com/15767602/77021247-93744600-695c-11ea-9538-ab8adf122e97.png">

This little mockup will do a better job explaining than I can. Now, instead of having to run both MongoDB and a Radiks server locally, we can all connect to the same Radiks server running on an AWS EC2 instance and persisting data we add / manipulate to the same database running on a MongoDB cluster.

For security purposes, as the EC2 instance is already a little insecure in terms of inbound traffic, and just for good practice, I've implemented a `REACT_APP_QA_URL` environment variable for the public DNS of the EC2. You can just ask me for it, or I'll figure out the best way to put in in the Discord or keep it secure.

Let me know if you have any questions / comments! 