### PR TITLE
Use @blockstack/connect for improved UX

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "prettier": "@blockstack/prettier-config",
   "dependencies": {
+    "@blockstack/connect": "^2.3.1",
     "@fortawesome/free-brands-svg-icons": "^5.12.1",
     "@material-ui/core": "^4.9.7",
     "@testing-library/jest-dom": "^5.1.1",

--- a/client/src/components/App.js
+++ b/client/src/components/App.js
@@ -9,7 +9,7 @@ import Patient from '../models/patient';
 import { Connect } from '@blockstack/connect';
 import DiagnosticContainer from './DiagnosticContainer';
 
-const RADIKS_URL = process.env.REACT_APP_QA_URL || 'http://127.0.0.1:5000'; // TODO this will change to wherever our radiks server will be hosted in prod
+const RADIKS_URL = process.env.REACT_APP_QA_URL || 'http://127.0.0.1:1260'; // TODO this will change to wherever our radiks server will be hosted in prod
 
 const makeUserSession = () => {
   return new UserSession({ appConfig });

--- a/client/src/components/Login.js
+++ b/client/src/components/Login.js
@@ -1,31 +1,36 @@
 import React from 'react';
-import '../css/Login.css'
-import '../css/App.css'
-import '../css/themePalette.css'
-import { ReactComponent as Logo} from '../img/Logo_CORONATRACKER_Logo.svg'
-import { ReactComponent as TextLogo } from '../img/Logo_CORONATRACKER_Text_Logo.svg'
+import '../css/Login.css';
+import '../css/App.css';
+import '../css/themePalette.css';
+import { ReactComponent as Logo } from '../img/Logo_CORONATRACKER_Logo.svg';
+import { ReactComponent as TextLogo } from '../img/Logo_CORONATRACKER_Text_Logo.svg';
 import Button from 'react-bootstrap/Button';
+import { useConnect } from '@blockstack/connect';
 
-function Login(props) {
-    const { handleSignIn } = props;
-    return (
-        <div className="Login">
-            <Logo className="LoginLogo"/>
-            <TextLogo className="TextLogo"/>
-            <p className="ShortDescriptionText">
-                Your health app to <b>monitor</b> flu-like symptoms, <b>connect</b> to telehealth doctors in your area and <b>discover</b> resources close to you.
-            </p>
-            <style type="text/css">
-                {`
+function Login() {
+  const { doOpenAuth } = useConnect();
+
+  return (
+    <div className="Login">
+      <Logo className="LoginLogo" />
+      <TextLogo className="TextLogo" />
+      <p className="ShortDescriptionText">
+        Your health app to <b>monitor</b> flu-like symptoms, <b>connect</b> to telehealth doctors in your area and{' '}
+        <b>discover</b> resources close to you.
+      </p>
+      <style type="text/css">
+        {`
                 .btn-login {
                     background-color: #f64141;
                     color: f64141;
                 }
                 `}
-            </style>
-            <Button variant="login" onClick={handleSignIn}>Sign in with Blockstack</Button>
-        </div>
-    );
+      </style>
+      <Button variant="login" onClick={doOpenAuth}>
+        Sign in with Blockstack
+      </Button>
+    </div>
+  );
 }
 
 export default Login;

--- a/client/src/components/Login.js
+++ b/client/src/components/Login.js
@@ -27,7 +27,7 @@ function Login() {
                 `}
       </style>
       <Button variant="login" onClick={doOpenAuth}>
-        Sign in with Blockstack
+        Get started
       </Button>
     </div>
   );


### PR DESCRIPTION
This PR
* replaces `blockstack.redirectToSignIn` with `connect.doOpenAuth`
* closes #93 

The connect library was developed by Blockstack's user experience team to improve the on-boarding of new users. 

**Test plan (required)**
1. start radiks or set QA_URL
1. Checkout this branch
1. `yarn`
1. `yarn start`
1. Visit 127.0.0.1:3000
1. if logged-in logout
1. click `Get started` and follow the out flow
1. click sign out

Sign In Flow
![Screenshot from 2020-03-20 09-59-37](https://user-images.githubusercontent.com/1449049/77149544-1ba83780-6a92-11ea-951a-af677494bf89.png)

Sign out Flow
![Screenshot from 2020-03-20 10-01-53](https://user-images.githubusercontent.com/1449049/77149542-1a770a80-6a92-11ea-81a3-bd9f79e9cf89.png)
