### PR TITLE
Setup demo prod deployment

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,9 +46,9 @@ You'll also need `radiks-server`, which you can install simply with
 1. Fork this repo `https://github.com/COVID-19-electronic-health-system/Corona-tracker`
 2. `cd Corona-tracker/client`
 3. `npm i`
-4. Create a new file, `.env`
+4. Create a new file, `.env.development`
 5. On the Discord server, navigate to the #welcome channel, and click the pin icon on the top right of the window. Copy the `REACT_APP_QA_URL` code from the pinned message from Carter Klein.
-6. In `.env`, write and save `REACT_APP_QA_URL: <THE-URL-CODE>`
+6. In `.env.development`, write and save `REACT_APP_QA_URL: <THE-URL-CODE>`
 7. `npm run start` - run the application locally
 
 #### BEFORE YOU MAKE CHANGES TO YOUR FORKED CODE VIA BRANCH OR MASTER

--- a/client/.env.production
+++ b/client/.env.production
@@ -1,0 +1,1 @@
+REACT_APP_QA_URL=http://ec2-54-165-39-76.compute-1.amazonaws.com:1260

--- a/client/.gitignore
+++ b/client/.gitignore
@@ -15,6 +15,7 @@
 .DS_Store
 .env
 .env.local
+.env.development
 .env.development.local
 .env.test.local
 .env.production.local


### PR DESCRIPTION
Closes #155 

## Changes
- Added a new Radiks cluster running on an EC2 instance, linked to a new MongoDB Atlas Cluster. This satisfies the condition @friedger actually specified a few months back to someone else who had a [similar question](https://github.com/blockstack/radiks/issues/40)! 
- Updated the `README` - we now have two environments, so we have two different environment variable files: `.env.development` and `.env.production`. For most cases, we'll be setting `.env.development` to access the QA environment. You should only be setting `.env.production` if you're looking to make prod changes, which should be thoroughly vetted.
