### PR TITLE
Add development environment variable to gitignore

### DIFF
--- a/client/.gitignore
+++ b/client/.gitignore
@@ -16,6 +16,7 @@
 .env
 .env.local
 .env.development
+.env.production
 .env.development.local
 .env.test.local
 .env.production.local


### PR DESCRIPTION
## Changes
- Added `.env.production` to our gitignore so that nobody can see our "demo prod" endpoint