### PR TITLE
#164 PrivateRoute component

### DIFF
--- a/client/src/components/App.js
+++ b/client/src/components/App.js
@@ -75,12 +75,16 @@ class App extends Component {
               />
 
               {/* ADD/EDIT ROUTES WITH THEIR COMPONENTS HERE: */}
-              <Route path="/signup" />
+              <PrivateRoute path="/signup" authed={authed} />
               <PrivateRoute path="/symptomsurvey" authed={authed} />
               <PrivateRoute path="/log" authed={authed} />
               <PrivateRoute path="/healthlog" authed={authed} />
-              <Route path="/education" render={() => <FactQuizContainer handleSignOut={this.handleSignOut} />} />
-              <Route path="/map" />
+              <PrivateRoute
+                path="/education"
+                authed={authed}
+                render={() => <FactQuizContainer handleSignOut={this.handleSignOut} />}
+              />
+              <PrivateRoute path="/map" authed={authed} />
               <PrivateRoute path="/settings" authed={authed} />
             </Switch>
           </div>

--- a/client/src/components/App.js
+++ b/client/src/components/App.js
@@ -11,6 +11,7 @@ import { BrowserRouter, Route, Switch } from 'react-router-dom';
 import { connect } from 'react-redux';
 import setLoginLoading from '../redux/actions/actions';
 import FactQuizContainer from './FactQuizContainer';
+import PrivateRoute from './PrivateRoute';
 
 const RADIKS_URL = process.env.REACT_APP_QA_URL || 'http://127.0.0.1:1260'; // TODO this will change to wherever our radiks server will be hosted in prod
 
@@ -61,29 +62,26 @@ class App extends Component {
     };
 
     const { authed, checkingAuth } = this.state;
-    console.log(this.state);
     return (
       <BrowserRouter>
         <Connect authOptions={authOptions}>
           <div className="App">
             <Switch>
-              <Route exact path="/">
-                {!authed ? (
-                  <>{checkingAuth ? <div>LOADING..</div> : <Login />}</>
-                ) : (
-                  <div>
-                    <DiagnosticContainer userSession={userSession} handleSignOut={this.handleSignOut} />
-                  </div>
-                )}
-              </Route>
+              <PrivateRoute
+                exact
+                path="/"
+                authed={authed}
+                component={() => <DiagnosticContainer userSession={userSession} handleSignOut={this.handleSignOut} />}
+              />
+
               {/* ADD/EDIT ROUTES WITH THEIR COMPONENTS HERE: */}
               <Route path="/signup" />
-              <Route path="/symptomsurvey" />
-              <Route path="/log" />
-              <Route path="/healthlog" />
+              <PrivateRoute path="/symptomsurvey" authed={authed} />
+              <PrivateRoute path="/log" authed={authed} />
+              <PrivateRoute path="/healthlog" authed={authed} />
               <Route path="/education" render={() => <FactQuizContainer handleSignOut={this.handleSignOut} />} />
               <Route path="/map" />
-              <Route path="/settings" />
+              <PrivateRoute path="/settings" authed={authed} />
             </Switch>
           </div>
         </Connect>
@@ -104,4 +102,7 @@ const mapDispatchToProps = dispatch => ({
   },
 });
 
-export default connect(mapStateToProps, mapDispatchToProps)(App);
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(App);

--- a/client/src/components/PrivateRoute.js
+++ b/client/src/components/PrivateRoute.js
@@ -1,0 +1,7 @@
+import React from 'react';
+import { Route } from 'react-router-dom';
+import Login from './Login';
+
+export default ({ path, component: Component, authed }) => {
+  return authed ? <Route path={path} component={Component} /> : <Login />;
+};


### PR DESCRIPTION
**Description of change** => replaces protected routes with PrivateRoute component, which receives as props the authed state, the path, and the component to render, and conditionally renders either the component received as a prop or the Login component.

**Alternate designs** => either keep authed state in redux so that we can connect the PrivateRoute component to the store and not need to pass authed on every route, or... I've been given the impression that there is a way that we can access the userSession data from Radiks in any component, so that could provide a similar solution. I have no experience in Radiks and haven't been able to figure out how to do that.

**Possible drawbacks** => need to pass authed boolean to every route, may eventually affect readability.