### PR TITLE
Fixed routing to Education 

### DIFF
--- a/client/src/components/App.js
+++ b/client/src/components/App.js
@@ -82,7 +82,7 @@ class App extends Component {
               <PrivateRoute
                 path="/education"
                 authed={authed}
-                render={() => <FactQuizContainer handleSignOut={this.handleSignOut} />}
+                component={() => <FactQuizContainer handleSignOut={this.handleSignOut} />}
               />
               <PrivateRoute path="/map" authed={authed} />
               <PrivateRoute path="/settings" authed={authed} />
@@ -106,7 +106,4 @@ const mapDispatchToProps = dispatch => ({
   },
 });
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(App);
+export default connect(mapStateToProps, mapDispatchToProps)(App);

--- a/client/src/components/Disclaimer.js
+++ b/client/src/components/Disclaimer.js
@@ -4,25 +4,32 @@ import { ReactComponent as TextLogo } from '../img/Logo_CORONATRACKER_Text_Logo.
 import Button from 'react-bootstrap/Button';
 
 function Disclaimer(props) {
+  const [modalHidden, setModalHidden] = React.useState(true);
   return (
-    <div className="DisclaimerPopUp">
-      <div className="DisclaimerPopUpInner">
-        <Logo className="LoginLogo" className="PopUpLogo" />
-        <TextLogo className="TextLogo" className="PopUpLogo" />
-        <p>
-          The CoronaTracker is designed to help you navigate through the pandemic with accurate information, charting
-          your wellbeing, and tracking your health. The CoronaTracker is not intended to be used or viewed as diagnosis
-          or treatment of disease or other symptoms, including but not limited to COVID-19.
-        </p>
-        <p>
-          This application was made by the community for the community. This application is made for you! You are in
-          control of how you would like to contribute your data for public health and research.
-        </p>
-        <div>
-          <Button className="theme-Palette-white-text">I agree</Button>
-          <Button className="theme-Palette-white-text theme-Palette-red-bg">I don't agree</Button>
+    <div>
+      {modalHidden ? (
+        <div className="DisclaimerPopUp">
+          <div className="DisclaimerPopUpInner">
+            <Logo className="LoginLogo" className="PopUpLogo" />
+            <TextLogo className="TextLogo" className="PopUpLogo" />
+            <p>
+              The CoronaTracker is designed to help you navigate through the pandemic with accurate information,
+              charting your wellbeing, and tracking your health. The CoronaTracker is not intended to be used or viewed
+              as diagnosis or treatment of disease or other symptoms, including but not limited to COVID-19.
+            </p>
+            <p>
+              This application was made by the community for the community. This application is made for you! You are in
+              control of how you would like to contribute your data for public health and research.
+            </p>
+            <div>
+              <Button className="theme-Palette-white-text" onClick={() => setModalHidden(false)}>
+                I agree
+              </Button>
+              <Button className="theme-Palette-white-text theme-Palette-red-bg">I don't agree</Button>
+            </div>
+          </div>
         </div>
-      </div>
+      ) : null}
     </div>
   );
 }

--- a/client/src/components/Disclaimer.js
+++ b/client/src/components/Disclaimer.js
@@ -4,32 +4,27 @@ import { ReactComponent as TextLogo } from '../img/Logo_CORONATRACKER_Text_Logo.
 import Button from 'react-bootstrap/Button';
 
 function Disclaimer(props) {
-  const [modalHidden, setModalHidden] = React.useState(true);
   return (
-    <div>
-      {modalHidden ? (
-        <div className="DisclaimerPopUp">
-          <div className="DisclaimerPopUpInner">
-            <Logo className="LoginLogo" className="PopUpLogo" />
-            <TextLogo className="TextLogo" className="PopUpLogo" />
-            <p>
-              The CoronaTracker is designed to help you navigate through the pandemic with accurate information,
-              charting your wellbeing, and tracking your health. The CoronaTracker is not intended to be used or viewed
-              as diagnosis or treatment of disease or other symptoms, including but not limited to COVID-19.
-            </p>
-            <p>
-              This application was made by the community for the community. This application is made for you! You are in
-              control of how you would like to contribute your data for public health and research.
-            </p>
-            <div>
-              <Button className="theme-Palette-white-text" onClick={() => setModalHidden(false)}>
-                I agree
-              </Button>
-              <Button className="theme-Palette-white-text theme-Palette-red-bg">I don't agree</Button>
-            </div>
-          </div>
+    <div className="DisclaimerPopUp">
+      <div className="DisclaimerPopUpInner">
+        <Logo className="LoginLogo" className="PopUpLogo" />
+        <TextLogo className="TextLogo" className="PopUpLogo" />
+        <p>
+          The CoronaTracker is designed to help you navigate through the pandemic with accurate information, charting
+          your wellbeing, and tracking your health. The CoronaTracker is not intended to be used or viewed as diagnosis
+          or treatment of disease or other symptoms, including but not limited to COVID-19.
+        </p>
+        <p>
+          This application was made by the community for the community. This application is made for you! You are in
+          control of how you would like to contribute your data for public health and research.
+        </p>
+        <div>
+          <Button className="theme-Palette-white-text" onClick={() => setModalHidden(false)}>
+            I agree
+          </Button>
+          <Button className="theme-Palette-white-text theme-Palette-red-bg">I don't agree</Button>
         </div>
-      ) : null}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
Changed attribute in PrivateRoute (render => component). You can now navigate to the education page. Also added state to the Disclaimer.js so when uncommented, the disclaimer will disappear after agreeing. 

fixes #196 