### PR TITLE
Subscribe to notifications service alpha via API Gateway

### DIFF
--- a/client/src/components/Subscribe.js
+++ b/client/src/components/Subscribe.js
@@ -1,14 +1,32 @@
-import React from 'react';
+import React, { useState } from 'react';
 import FormControl from '@material-ui/core/FormControl'
 import { TextField, Button, Slide } from '@material-ui/core';
+import axios from 'axios';
 
 const Subscribe = (props) => {
+  const [number, setNumber] = useState('')
+
+  function subscribe() {
+    axios.post('https://m72j7fayxh.execute-api.us-east-1.amazonaws.com/api/subscribe', {
+      "number": number
+    }, {
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded"
+      }
+    }).then(res => {
+      console.log(res)
+      alert(`Subscribed successfully! You will be automatically unsubscribed in one day, and will receive three texts in that timespan. If you enter again, you will receive double the notifications - so please do not! This is very early alpha :)`)
+    }).catch(err => {
+      console.log(err)
+    })
+  }
+
     return (
       <div className={"SubscribeContainer"}>
         <Slide direction="right" in={true} mountOnEnter unmountOnExit>
           <FormControl>
-            <TextField id="filled-phone" label="Enter Phone Number" value={''} onChange={() => {}} variant="filled" />
-            <Button variant="contained" color="secondary">
+            <TextField id="filled-phone" label="Enter Phone Number" onChange={(e) => setNumber(e.target.value)} variant="filled" />
+            <Button onClick={() => subscribe()} variant="contained" color="secondary">
               Subscribe for alerts
             </Button>
           </FormControl>


### PR DESCRIPTION
fixes #248 

This wires up the frontend button to request subscription to our notifications service to the backend API which subscribes the user. 

**NOTE:** I am hardcoding in the URL, but I believe this is fine as the request is being sent over HTTPS, not HTTP.

Right now, this backend service is very rudimentary. Unsubscribe functionality is currently not fully working, so for now, we're just subscribing a user for one day, at which point the server will reset and all data will be lost (thus unsubscribing the user). This is incredibly hacky, but between making sure everything else is running smoothly and trying to push this out in 2 days, it's the best I could do :)

Currently, the service is deployed on my private AWS account. Going forward, I will look to create at least a free-tier AWS account so we can all work on the backend and architecture work together. I will also figure out how to best manage passwords in open source.