### PR TITLE
Used useHistory to redirect to health log on survey submission

### DIFF
--- a/client/src/components/SymptomsTracker.js
+++ b/client/src/components/SymptomsTracker.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react';
+import { useHistory } from 'react-router-dom';
 import { makeStyles } from '@material-ui/core/styles';
 import { Typography, Slider, ButtonGroup, Button, TextField, Grid } from '@material-ui/core';
 import CheckboxButton from './survey-view/checkbox-button/CheckboxButton';
@@ -82,6 +83,7 @@ const SymptomsTracker = () => {
   const { userSession } = useBlockstack();
   const childRef = useRef();
   const classes = useStyles();
+  const history = useHistory();
 
   // emulate dynamic state in a fuctional component
   const [todayFeeling, setTodayFeeling] = useState(1);
@@ -144,7 +146,7 @@ const SymptomsTracker = () => {
     const observation = childRef.current.createObservation(submission)
     const encryptOptions = { encrypt: true };
     userSession.putFile(`observation/0000000${numObservations+1}.json`, JSON.stringify(observation.attrs), encryptOptions).then((res) => {
-      window.location.reload()
+      history.push('/');
     }).catch(err => {
       console.log(err)
     })


### PR DESCRIPTION
fixes #292 

## Changes
- as title states, we're not using `window.location.reload()` anymore, as that breaks the authentication and will not work in production