### PR TITLE
#318 disable severity buttons unless the symptom is checked

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "corona-tracker",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "private": true,
   "prettier": "@blockstack/prettier-config",
   "husky": {

--- a/client/src/components/survey-view/checkbox-button/SingleCheckboxButton.jsx
+++ b/client/src/components/survey-view/checkbox-button/SingleCheckboxButton.jsx
@@ -194,6 +194,7 @@ export default function SingleCheckboxButton(props) {
           <Button
             variant="contained"
             name={symptomName}
+            disabled={!symptomChecked}
             onClick={symptomChecked ? handleButtonGroupChange : () => {}}
             color={symptomValue === 'Minimal' ? 'secondary' : 'primary'}
             value="Minimal"
@@ -204,6 +205,7 @@ export default function SingleCheckboxButton(props) {
           <Button
             variant="contained"
             name={symptomName}
+            disabled={!symptomChecked}
             onClick={symptomChecked ? handleButtonGroupChange : () => {}}
             color={symptomValue === 'Moderate' ? 'secondary' : 'primary'}
             value="Moderate"
@@ -214,6 +216,7 @@ export default function SingleCheckboxButton(props) {
           <Button
             variant="contained"
             name={symptomName}
+            disabled={!symptomChecked}
             onClick={symptomChecked ? handleButtonGroupChange : () => {}}
             color={symptomValue === 'Severe' ? 'secondary' : 'primary'}
             value="Severe"


### PR DESCRIPTION
Simply checks the symptom checkbox to determine whether the severity buttons should be disabled or not.

fixes #318 