### PR TITLE
Show WeeklyTrackers on date click

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "corona-tracker",
-  "version": "0.2.12",
+  "version": "0.2.13",
   "private": true,
   "prettier": "@blockstack/prettier-config",
   "husky": {

--- a/client/src/components/DiagnosticContainer.jsx
+++ b/client/src/components/DiagnosticContainer.jsx
@@ -49,7 +49,7 @@ function DiagnosticContainer(props) {
   let numObservations = 0;
   const fetchFiles = async () => {
     for (let i = 0; i < files.length; i += 1) {
-      if (files[i].includes('observation')) {
+      if (files[i].includes('observation/')) {
         const currObservation = parseInt(files[i].replace(/^\D+/g, ''), 10);
         numObservations = currObservation;
       }

--- a/client/src/components/MyHealthLog.jsx
+++ b/client/src/components/MyHealthLog.jsx
@@ -3,8 +3,6 @@ import Button from '@material-ui/core/Button';
 import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { Grid, makeStyles } from '@material-ui/core';
-import WeeklyTracker from './WeeklyTracker';
-import WeeklyTrackerDay from './WeeklyTrackerDay';
 import AppCalendar from './Calendar';
 
 const useStyles = makeStyles({
@@ -16,17 +14,6 @@ const useStyles = makeStyles({
     color: 'white',
   },
 });
-
-const dates = [
-  {
-    date: 11,
-    day: 'Monday',
-    status: '10',
-    temp: 99.6,
-    symptoms: 'headache',
-    comments: 'Tired for the entire day',
-  },
-];
 
 function HealthLogButton() {
   const { t } = useTranslation();
@@ -40,11 +27,6 @@ function HealthLogButton() {
       </Link>
       <Grid container direction="column" alignContent="center">
         <AppCalendar />
-        {dates.map(dayData => (
-          <WeeklyTracker key={dayData.date}>
-            <WeeklyTrackerDay dayData={dayData} />
-          </WeeklyTracker>
-        ))}
       </Grid>
     </div>
   );

--- a/client/src/components/WeeklyTracker.jsx
+++ b/client/src/components/WeeklyTracker.jsx
@@ -4,13 +4,13 @@ import React from 'react';
 import { makeStyles } from '@material-ui/core/styles';
 import { useSpring, animated, interpolate } from 'react-spring';
 import { useGesture } from 'react-with-gesture';
-import PropTypes, { object } from 'prop-types';
+import PropTypes from 'prop-types';
 
 const useStyles = makeStyles({
   item: {
     position: 'relative',
     width: '100vw',
-    height: '10vh',
+    height: '15vh',
     pointerEvents: 'auto',
     transformOrigin: '50% 50% 0px',
     paddingLeft: '32px',
@@ -49,6 +49,10 @@ const useStyles = makeStyles({
     borderRadius: '50%',
     backgroundColor: 'white',
   },
+  weeklyTrackerContainer: {
+    left: '0',
+    transform: 'translateX(-50%)',
+  },
 });
 
 const WeeklyTracker = props => {
@@ -68,7 +72,7 @@ const WeeklyTracker = props => {
     extrapolate: 'clamp',
   });
   return (
-    <div className="weekly-tracker-container">
+    <div className={classes.weeklyTrackerContainer}>
       <animated.div {...bind()} className={classes.item} style={{ background: bg }}>
         <animated.div
           className={classes.av}
@@ -86,7 +90,11 @@ const WeeklyTracker = props => {
 };
 
 WeeklyTracker.propTypes = {
-  children: PropTypes.objectOf(object).isRequired,
+  children: PropTypes.string,
+};
+
+WeeklyTracker.defaultProps = {
+  children: '',
 };
 
 export default WeeklyTracker;

--- a/client/src/components/WeeklyTrackerDay.jsx
+++ b/client/src/components/WeeklyTrackerDay.jsx
@@ -23,7 +23,9 @@ const useStyles = makeStyles(() => ({
 
 const WeeklyTrackerDay = props => {
   const classes = useStyles();
-  const { dayData } = props;
+  let { dayData } = props;
+  dayData = JSON.parse(dayData);
+
   return (
     <div className={classes.div}>
       <Grid container spacing={0} className="day-container">
@@ -31,20 +33,19 @@ const WeeklyTrackerDay = props => {
           <img alt="threeLinesSvg" src={CalendarThreeLines} />
         </Grid>
         <Grid item className={classes.topMargin}>
-          <Typography variant="h4">{dayData.date}</Typography>
+          <Typography variant="h5">{new Date(dayData.date).toISOString().slice(0, 10)}</Typography>
         </Grid>
         <Grid item className={classes.summary}>
-          <Typography variant="subtitle2">You felt: {dayData.status}/10</Typography>
-          <Typography variant="subtitle2">{dayData.day} </Typography>
+          <Typography variant="subtitle2">You felt: {dayData.physical.dailyfeeling}/10</Typography>
         </Grid>
         <Grid item>
           <Typography variant="subtitle2">
-            Fever: <strong>{dayData.temp}</strong>
+            Fever? <strong>{dayData.physical.hasfever.toString()}</strong>
           </Typography>
           <Typography variant="subtitle2">
-            Symptoms: <strong>{dayData.symptoms}</strong>
+            Cough? <strong>{dayData.physical.hasCough.toString()}</strong>
           </Typography>
-          <Typography variant="subtitle2">Comments: ugh</Typography>
+          <Typography variant="subtitle2">Comments: {dayData.nonPhysical.openComment}</Typography>
         </Grid>
       </Grid>
     </div>
@@ -53,19 +54,6 @@ const WeeklyTrackerDay = props => {
 
 WeeklyTrackerDay.propTypes = {
   dayData: PropTypes.objectOf(object).isRequired,
-  date: PropTypes.number,
-  day: PropTypes.string,
-  status: PropTypes.string,
-  temp: PropTypes.number,
-  symptoms: PropTypes.string,
-};
-
-WeeklyTrackerDay.defaultProps = {
-  date: 0,
-  day: '0/0/0000',
-  status: 'n/a',
-  temp: 0,
-  symptoms: 'n/a',
 };
 
 export default WeeklyTrackerDay;

--- a/client/src/tests/Calendar.test.jsx
+++ b/client/src/tests/Calendar.test.jsx
@@ -1,3 +1,13 @@
-test('renders Calendar component', () => {
-  // render(<AppCalendar />); DOESN'T WORK FOR TOP-LEVEL TESTS. NEEDS TO BE PLACED UNDER A ROUTER
+import React from 'react';
+import Calendar from 'react-calendar/dist/umd/Calendar';
+import { render } from '@testing-library/react';
+
+// describe('Calendar', () => {
+//   it('should render a Calendar component', () => {
+//     return <Calendar />;
+//   });
+// });
+
+test('renders a Calendar component', () => {
+  render(<Calendar />);
 });


### PR DESCRIPTION
## IMPORTANT: Please do not create a Pull Request without creating an issue first.

**Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.**

**Do not change the following line aside from replacing YOUR-ISSUE-HERE with the issue this PR fixes** 

fixes #338 

### Please provide enough information so that others can review your pull request:

### Explain the **details** for making this change. What existing problem does the pull request solve?

Added functionality so that when the user clikcs on a calendar date, the associated WeeklyTracker components will display below the calendar. Definitely need styling (I will make another issue), but it works.

![calendar-click](https://user-images.githubusercontent.com/15767602/78408815-18569500-75d6-11ea-98be-5041476ab5b3.gif)

### Test plan (required)

Added a basic Calendar-rendering test - **as I've said in other PRs - will write out individual stories to backfill tests. I know it's not good practice, but we have 12 days until beta**.

Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.

<!-- Make sure tests pass on both Travis and Circle CI. -->

### Final Checklist

- [x] Have you bumped the version in `package.json`?
    - Second decimal for major change, third decimal for minor change. This can go past 10 i.e. 1.0.9 !=> 1.1.0, 1.0.9 => 1.0.10
    - [Read here for more info](https://semver.org/)
- [x] Have you added any new tests necessary?
- [x] Is your PR rebased off the most current master?
- [x] Have you squashed all commits, or if you will merge will you squash all commits?
- [x] Did you use yarn, not npm?
- [x] Did you use Material-UI wherever possible?
- [x] Did you format according to Prettier?
- [x] Did you run all of your most recent changes locally to make sure everything is working?