### PR TITLE
Removed react-with-gesture

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "corona-tracker",
-  "version": "0.3.24",
+  "version": "0.3.25",
   "private": true,
   "prettier": "@blockstack/prettier-config",
   "husky": {
@@ -48,7 +48,6 @@
     "react-spring": "^9.0.0-canary.808.11.4be2ac3",
     "react-test-renderer": "16.9.0",
     "react-use-gesture": "^7.0.0-beta.1",
-    "react-with-gesture": "^4.0.8",
     "redux": "^4.0.5",
     "redux-logger": "^3.0.6",
     "redux-mock-store": "1.5.3",

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -11366,11 +11366,6 @@ react-use-gesture@^7.0.0-beta.1:
   resolved "https://registry.yarnpkg.com/react-use-gesture/-/react-use-gesture-7.0.9.tgz#0a36a992564d7c07f741da474ff1f3f25b6ef06d"
   integrity sha512-z2gNEZhMBiyVRF7g+n54oA/1abEd+v6k99KqlzR+emG+I90rFXBG8U0ftk0h0B3MUxXcBWHZJijlrNQhS6iLAw==
 
-react-with-gesture@^4.0.8:
-  version "4.0.8"
-  resolved "https://registry.yarnpkg.com/react-with-gesture/-/react-with-gesture-4.0.8.tgz#ce6db9e667ef13120797e641f1a00f934aed6c36"
-  integrity sha512-VIJ1K2/UT67m+OnqYIgJUdYEqVmJDPfbZBoqUMYKts6WA0EbEC7YRMBEzxgy/jvVdafg9L2GSuFtUokpskKHag==
-
 react@^16.12.0, react@^16.13.0:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react/-/react-16.13.1.tgz#2e818822f1a9743122c063d6410d85c1e3afe48e"


### PR DESCRIPTION
fixes #405 

### Please provide enough information so that others can review your pull request:

Ran yarn remove react-with-gesture

### Explain the **details** for making this change. What existing problem does the pull request solve?

To remove deprecated dependancy on react-with-gesture for focus on react-use-gesture

### Test plan (required)

Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.

Sorry I didn't think to take a screenshot of the command output before running yarn run start to test. The output had some warnings but no errors. The fact that there are no changes in the package.json and yarn.lock files supports this. I also tested the drag gesture and it works both on my phone and on desktop. 
https://gyazo.com/e6279b18c09c3a2ac59753858f4c4983

<!-- Make sure tests pass on both Travis and Circle CI. -->

### Final Checklist

- [x] Have you bumped the version in `package.json`?
    - Second decimal for major change, third decimal for minor change. This can go past 10 i.e. 1.0.9 !=> 1.1.0, 1.0.9 => 1.0.10
    - [Read here for more info](https://semver.org/)
- [x] Have you added any new tests necessary?
- [x] Is your PR rebased off the most current master?
- [ ] Have you squashed all commits, or if you will merge will you squash all commits?
- [x] Did you use yarn, not npm?
- [x] Did you use Material-UI wherever possible?
- [ ] Did you format according to Prettier?
- [x] Did you run all of your most recent changes locally to make sure everything is working?