### PR TITLE
Onboard form displays previous saved user data

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "corona-tracker",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "homepage": ".",
   "private": true,
   "prettier": "@blockstack/prettier-config",

--- a/client/src/components/App.jsx
+++ b/client/src/components/App.jsx
@@ -44,7 +44,7 @@ const App = props => {
       fetchObservations(userSession);
       fetchDemographicsComorbidities(userSession);
     }
-  }, [fetchObservations, authenticated, userSession]);
+  }, [fetchObservations, fetchDemographicsComorbidities, authenticated, userSession]);
 
   const [disclaimerString] = useFile('disclaimer.json');
 

--- a/client/src/components/App.jsx
+++ b/client/src/components/App.jsx
@@ -23,7 +23,7 @@ import ScrollToTop from './ScrollToTop';
 ReactBlockstack({ appConfig });
 
 const App = props => {
-  const { setLoading, fetchObservations } = props;
+  const { setLoading, fetchObservations, fetchDemographicsComorbidities } = props;
   const { userSession, authenticated } = useBlockstack();
   const finished = useCallback(() => {
     didConnect({ userSession });
@@ -42,6 +42,7 @@ const App = props => {
   useEffect(() => {
     if (authenticated) {
       fetchObservations(userSession);
+      fetchDemographicsComorbidities(userSession);
     }
   }, [fetchObservations, authenticated, userSession]);
 
@@ -92,11 +93,13 @@ const App = props => {
 App.propTypes = {
   setLoading: PropTypes.func.isRequired,
   fetchObservations: PropTypes.func.isRequired,
+  fetchDemographicsComorbidities: PropTypes.func.isRequired,
 };
 
 const mapDispatchToProps = dispatch => ({
   setLoading: isLoading => dispatch(actions.setLoginLoading(isLoading)),
   fetchObservations: userSession => dispatch(actions.fetchObservations(userSession)),
+  fetchDemographicsComorbidities: userSession => dispatch(actions.fetchDemographicsComorbidities(userSession)),
 });
 
 export default connect(null, mapDispatchToProps)(App);

--- a/client/src/components/OnboardUser.jsx
+++ b/client/src/components/OnboardUser.jsx
@@ -78,19 +78,11 @@ const useStyles = makeStyles(() => ({
   },
 }));
 
-const blankForm = {
-  age: '',
-  gender: '',
-  city: '',
-  state: '',
-  zip: '',
-};
-
 const OnboardUser = props => {
   const history = useHistory();
-  const { setDemographicsComorbiditiesThunk } = props;
+  const { setDemographicsComorbiditiesThunk, demographicsComorbidities } = props;
   const { userSession } = useBlockstack();
-  const [formState, setFormState] = useState(blankForm);
+  const [formState, setFormState] = useState(demographicsComorbidities);
   const [showDeletionDialog, setShowDeletionDialog] = useState(false);
   const handleChange = e => {
     e.preventDefault();
@@ -436,13 +428,32 @@ const OnboardUser = props => {
 
 OnboardUser.propTypes = {
   setDemographicsComorbiditiesThunk: PropTypes.func.isRequired,
+  demographicsComorbidities: PropTypes.shape({
+    age: PropTypes.string,
+    gender: PropTypes.string,
+    city: PropTypes.string,
+    state: PropTypes.string,
+    zip: PropTypes.string,
+    isSmoker: PropTypes.string,
+    isObese: PropTypes.string,
+    isAsthmatic: PropTypes.string,
+  }).isRequired,
+};
+
+const mapStateToProps = state => {
+  return {
+    demographicsComorbidities: state.onboardingReducer.demographicsComorbidities,
+  };
 };
 
 const mapDispatchToProps = dispatch => {
   return {
     setDemographicsComorbiditiesThunk: (formData, userSession) =>
       dispatch(actions.setDemographicsComorbiditiesThunk(formData, userSession)),
+    fetchDemographicsComorbidities: userSession => {
+      dispatch(actions.fetchDemographicsComorbidities(userSession));
+    },
   };
 };
 
-export default connect(null, mapDispatchToProps)(OnboardUser);
+export default connect(mapStateToProps, mapDispatchToProps)(OnboardUser);

--- a/client/src/redux/actions/actions.js
+++ b/client/src/redux/actions/actions.js
@@ -23,7 +23,11 @@ import {
   toSurveyPage4,
   clearSurvey,
 } from './survey';
-import { setDemographicsComorbiditiesThunk, resetDemographicsComorbidities } from './onboarding';
+import {
+  setDemographicsComorbiditiesThunk,
+  resetDemographicsComorbidities,
+  fetchDemographicsComorbidities,
+} from './onboarding';
 import { deleteUserDataThunk } from './deleteUserData';
 
 const actions = {
@@ -47,6 +51,7 @@ const actions = {
   toSurveyPage4,
   clearSurvey,
   setDemographicsComorbiditiesThunk,
+  fetchDemographicsComorbidities,
   resetDisclaimerAnswer,
   resetDemographicsComorbidities,
   deleteUserDataThunk,

--- a/client/src/redux/actions/onboarding.js
+++ b/client/src/redux/actions/onboarding.js
@@ -1,4 +1,5 @@
 /* eslint-disable no-console */
+export const FETCH_DEMOGRAPHICS_COMORBIDITIES = 'FETCH_DEMOGRAPHICS_COMORBIDITIES';
 
 export const SET_DEMOGRAPHICS_COMORBIDITIES = 'SET_DEMOGRAPHICS_COMORBIDITIES';
 
@@ -19,7 +20,11 @@ export function resetDemographicsComorbidities() {
 
 export const fetchDemographicsComorbidities = userSession => async dispatch => {
   const data = await userSession.getFile(`demographics-comorbidities.json`);
-  if (data) dispatch(setDemographicsComorbidities(JSON.parse(data)));
+  if (data)
+    dispatch({
+      type: FETCH_DEMOGRAPHICS_COMORBIDITIES,
+      payload: JSON.parse(data),
+    });
 };
 
 export const setDemographicsComorbiditiesThunk = (formData, userSession) => async dispatch => {

--- a/client/src/redux/reducers/onboarding.js
+++ b/client/src/redux/reducers/onboarding.js
@@ -1,7 +1,20 @@
-import { SET_DEMOGRAPHICS_COMORBIDITIES, RESET_DEMOGRAPHICS_COMORBIDITIES } from '../actions/onboarding';
+import {
+  SET_DEMOGRAPHICS_COMORBIDITIES,
+  RESET_DEMOGRAPHICS_COMORBIDITIES,
+  FETCH_DEMOGRAPHICS_COMORBIDITIES,
+} from '../actions/onboarding';
 
 const initialState = {
-  demographicsComorbidities: {},
+  demographicsComorbidities: {
+    age: '',
+    gender: '',
+    city: '',
+    state: '',
+    zip: '',
+    isSmoker: '',
+    isObese: '',
+    isAsthmatic: '',
+  },
 };
 
 const onboardingReducer = (state = initialState, action) => {
@@ -10,6 +23,11 @@ const onboardingReducer = (state = initialState, action) => {
       return {
         ...state,
         demographicsComorbidities: action.formData,
+      };
+    case FETCH_DEMOGRAPHICS_COMORBIDITIES:
+      return {
+        ...state,
+        demographicsComorbidities: action.payload,
       };
     case RESET_DEMOGRAPHICS_COMORBIDITIES:
       return {

--- a/client/src/tests/redux/reducers/onboarding.test.js
+++ b/client/src/tests/redux/reducers/onboarding.test.js
@@ -3,18 +3,38 @@ import reducer from '../../../redux/reducers/onboarding';
 import { SET_DEMOGRAPHICS_COMORBIDITIES } from '../../../redux/actions/onboarding';
 
 describe('onboarding reducer', () => {
+  const initialState = {
+    demographicsComorbidities: {
+      age: '',
+      gender: '',
+      city: '',
+      state: '',
+      zip: '',
+      isSmoker: '',
+      isObese: '',
+      isAsthmatic: '',
+    },
+  };
+
   it('should return the initial state', () => {
-    expect(reducer(undefined, {})).toEqual({
-      demographicsComorbidities: {},
-    });
+    expect(reducer(initialState, {})).toEqual(initialState);
   });
 
   it('should handle SET_DEMOGRAPHICS_COMORBIDITIES', () => {
-    const formData = {};
+    const formData = {
+      age: '22',
+      gender: 'male',
+      city: 'long beach',
+      state: 'NY',
+      zip: '11561',
+      isSmoker: 'yes',
+      isObese: 'no',
+      isAsthmatic: 'no',
+    };
     const setDemographicsComorbidities = {
       type: SET_DEMOGRAPHICS_COMORBIDITIES,
-      formData: [formData],
+      formData,
     };
-    expect(reducer({}, setDemographicsComorbidities)).toEqual({ demographicsComorbidities: [formData] });
+    expect(reducer(initialState, setDemographicsComorbidities)).toEqual({ demographicsComorbidities: formData });
   });
 });


### PR DESCRIPTION
## IMPORTANT: Please do not create a Pull Request without creating an issue first.

**Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.**

**Do not change the following line aside from replacing YOUR-ISSUE-HERE with the issue this PR fixes** 

fixes #541 

### Please provide enough information so that others can review your pull request:

Previously saved user data should be displayed as the default values on the user onboard form, rather than a blank form.

### Explain the **details** for making this change. What existing problem does the pull request solve?

Initial form state was previously hardcoded in onboard component.  Initial formstate in component is now the user's onboard data state mapped from redux store.  Initial state in the store updated to reflect the shape of a blank form.  Redux action changed to reflect fetching vs setting the user's onboard data.  Fetch action added to useEffect in App.jsx.

### Test plan (required)

![onboardform](https://user-images.githubusercontent.com/15807680/79587263-4640dc80-80a0-11ea-899c-ea016fbd8f6e.gif)

<!-- Make sure tests pass on both Travis and Circle CI. -->

### Final Checklist

- [ ] Have you bumped the version in `package.json`?
    - Second decimal for major change, third decimal for minor change. This can go past 10 i.e. 1.0.9 !=> 1.1.0, 1.0.9 => 1.0.10
    - [Read here for more info](https://semver.org/)
- [x] Have you added any new tests necessary?
- [X ] Is your PR rebased off the most current master?
- [ ] Have you squashed all commits, or if you will merge will you squash all commits?
- [ X] Did you use yarn, not npm?
- [ X] Did you use Material-UI wherever possible?
- [ X] Did you format according to Prettier?
- [ X] Did you run all of your most recent changes locally to make sure everything is working?
