### PR TITLE
Refactor of the Table component

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "corona-tracker",
-  "version": "1.0.20",
+  "version": "1.0.21",
   "homepage": ".",
   "private": true,
   "prettier": "@blockstack/prettier-config",

--- a/client/src/components/Table.jsx
+++ b/client/src/components/Table.jsx
@@ -22,14 +22,11 @@ import buttonsCss from '../css/buttons';
 
 const useStyles = makeStyles(() => ({
   behaveDiv: {
-    paddingBottom: '20em',
     height: 700,
     overflow: 'auto',
   },
   feverDiv: {
-    height: 700,
     overflow: 'auto',
-    marginBottom: '10px',
   },
   buttons: {
     ...buttonsCss.buttons,
@@ -98,6 +95,19 @@ const LogTable = props => {
     <>
       <div>
         <Button className={classes.buttons}>Export to Excel</Button>
+        <div>
+          <FormControlLabel
+            control={<Checkbox checked={feverClicked} onChange={handleChange} color="secondary" name="Fever" />}
+            label="Fever"
+          />
+          <FormControlLabel
+            control={<Checkbox checked={behaveClicked} onChange={handleChange} name="Behavioral" color="secondary" />}
+            label="Behavioral"
+          />
+        </div>
+        {renderBehavior}
+        <br />
+        {renderFever}
         <TableContainer>
           <Table className="table">
             <TableHead className="table-head">
@@ -131,20 +141,7 @@ const LogTable = props => {
             ))}
           </Table>
         </TableContainer>
-        <div>
-          <FormControlLabel
-            control={<Checkbox checked={feverClicked} onChange={handleChange} color="secondary" name="Fever" />}
-            label="Fever"
-          />
-          <FormControlLabel
-            control={<Checkbox checked={behaveClicked} onChange={handleChange} name="Behavioral" color="secondary" />}
-            label="Behavioral"
-          />
-        </div>
       </div>
-      {renderBehavior}
-      <br />
-      {renderFever}
     </>
   );
 };

--- a/client/src/components/Table.jsx
+++ b/client/src/components/Table.jsx
@@ -22,11 +22,13 @@ import buttonsCss from '../css/buttons';
 
 const useStyles = makeStyles(() => ({
   behaveDiv: {
+    paddingBottom: '15%',
     height: 700,
     overflow: 'auto',
   },
   feverDiv: {
     overflow: 'auto',
+    paddingBottom: '15%',
   },
   buttons: {
     ...buttonsCss.buttons,
@@ -57,6 +59,7 @@ const LogTable = props => {
 
   const [behaveClicked, setBehaveClicked] = useState(false);
   const [feverClicked, setFeverClicked] = useState(false);
+
   const renderBehavior = behaveClicked ? (
     <div className={classes.behaveDiv}>
       <BehavioralChart />
@@ -75,9 +78,11 @@ const LogTable = props => {
     switch (targetName) {
       case 'Fever':
         setFeverClicked(!feverClicked);
+        setBehaveClicked(false);
         break;
       case 'Behavioral':
         setBehaveClicked(!behaveClicked);
+        setFeverClicked(false);
         break;
       default:
         break;
@@ -90,7 +95,6 @@ const LogTable = props => {
     }
     return `${value}${suffix}`;
   };
-
   return (
     <>
       <div>
@@ -108,7 +112,7 @@ const LogTable = props => {
         {renderBehavior}
         <br />
         {renderFever}
-        <TableContainer>
+        {!feverClicked && !behaveClicked ? <TableContainer>
           <Table className="table">
             <TableHead className="table-head">
               <TableRow>
@@ -140,7 +144,8 @@ const LogTable = props => {
               </TableBody>
             ))}
           </Table>
-        </TableContainer>
+        </TableContainer> : null}
+        
       </div>
     </>
   );


### PR DESCRIPTION
Fixes #619

## Summary

- user can select charts with many records in the table

## Details

- Move charts checkboxes above table with survey results
- Move charts above table with survey results
- Adjust style of the charts container to fix gap between chart and table containers
- Add dynamic rendering of the charts and table of the survey results

## Test Plan (required)

- yarn start
- click `show me more`
- select `Fever` or `Behavioral` 

## Suggestion

I think that `show me more` view is overloaded with 2 charts and survey results table. I would suggest conditional rendering based on user selection. If user select fever chart, we can hide table to make view let over loaded with content. Open for dialog!  

## Final Checklist

- [x] For CoronaTracker, did you bump the version in `package.json`?
    - Update the second decimal for a major change
    - Update the third decimal for a minor change
    - Numbers can go past 9, e.g. `1.0.9` => `1.0.10`
    - For more info, read about [Semantic Versioning](https://semver.org/)
- [x] Did you add any new tests as necessary?
- [x] Is your PR rebased off the most current master?
- [x] Have you squashed all commits? _(can be done at merge)_
- [x] Did you use `yarn` not `npm`? _(important!)_
- [x] Did you use Material-UI wherever possible?
- [x] Did you run `yarn lint` on the code?
- [x] Did you run all of your most recent changes locally to make sure everything is working?
