### PR TITLE
Redux-subscribe

### DIFF
--- a/client/src/components/App.jsx
+++ b/client/src/components/App.jsx
@@ -45,7 +45,7 @@ const App = props => {
       fetchDemographicsComorbidities(userSession);
       fetchSubscribedNumber(userSession);
     }
-  }, [fetchObservations, fetchDemographicsComorbidities, authenticated, userSession]);
+  }, [fetchObservations, fetchDemographicsComorbidities, fetchSubscribedNumber, authenticated, userSession]);
 
   const [disclaimerString] = useFile('disclaimer.json');
 
@@ -103,7 +103,4 @@ const mapDispatchToProps = dispatch => ({
   fetchSubscribedNumber: userSession => dispatch(actions.fetchSubscribedNumber(userSession)),
 });
 
-export default connect(
-  null,
-  mapDispatchToProps
-)(App);
+export default connect(null, mapDispatchToProps)(App);

--- a/client/src/components/App.jsx
+++ b/client/src/components/App.jsx
@@ -109,7 +109,4 @@ const mapDispatchToProps = dispatch => ({
   fetchSubscribedNumber: userSession => dispatch(actions.fetchSubscribedNumber(userSession)),
 });
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(App);
+export default connect(mapStateToProps, mapDispatchToProps)(App);

--- a/client/src/components/App.jsx
+++ b/client/src/components/App.jsx
@@ -23,7 +23,7 @@ import Settings from './Settings';
 ReactBlockstack({ appConfig });
 
 const App = props => {
-  const { fetchObservations, fetchDemographicsComorbidities } = props;
+  const { fetchObservations, fetchDemographicsComorbidities, fetchSubscribedNumber } = props;
   const { userSession, authenticated } = useBlockstack();
   const finished = useCallback(() => {
     didConnect({ userSession });
@@ -43,6 +43,7 @@ const App = props => {
     if (authenticated) {
       fetchObservations(userSession);
       fetchDemographicsComorbidities(userSession);
+      fetchSubscribedNumber(userSession);
     }
   }, [fetchObservations, fetchDemographicsComorbidities, authenticated, userSession]);
 
@@ -93,11 +94,16 @@ const App = props => {
 App.propTypes = {
   fetchObservations: PropTypes.func.isRequired,
   fetchDemographicsComorbidities: PropTypes.func.isRequired,
+  fetchSubscribedNumber: PropTypes.func.isRequired,
 };
 
 const mapDispatchToProps = dispatch => ({
   fetchObservations: userSession => dispatch(actions.fetchObservations(userSession)),
   fetchDemographicsComorbidities: userSession => dispatch(actions.fetchDemographicsComorbidities(userSession)),
+  fetchSubscribedNumber: userSession => dispatch(actions.fetchSubscribedNumber(userSession)),
 });
 
-export default connect(null, mapDispatchToProps)(App);
+export default connect(
+  null,
+  mapDispatchToProps
+)(App);

--- a/client/src/components/More.jsx
+++ b/client/src/components/More.jsx
@@ -115,7 +115,6 @@ const More = ({ setSubscribedNumber, unsubscribeNumber, subscribedNumber, clearR
   };
 
   const handleCloseSnackbar = (event, reason) => {
-    console.log(event, reason);
     if (reason === 'clickaway') {
       return;
     }
@@ -140,7 +139,8 @@ const More = ({ setSubscribedNumber, unsubscribeNumber, subscribedNumber, clearR
   };
 
   useEffect(() => {
-    let message, severity;
+    let message;
+    let severity;
     if (error.response) {
       severity = 'error';
       if (error.response.status === 409) {
@@ -295,7 +295,12 @@ const More = ({ setSubscribedNumber, unsubscribeNumber, subscribedNumber, clearR
 More.propTypes = {
   setSubscribedNumber: PropTypes.func.isRequired,
   unsubscribeNumber: PropTypes.func.isRequired,
-  subscribeError: PropTypes.objectOf(Object).isRequired,
+  error: PropTypes.shape({
+    response: PropTypes.shape({
+      status: PropTypes.number,
+    }),
+  }).isRequired,
+  success: PropTypes.string.isRequired,
   clearResponse: PropTypes.func.isRequired,
   subscribedNumber: PropTypes.string.isRequired,
 };
@@ -316,7 +321,4 @@ const mapDispatch = dispatch => {
   };
 };
 
-export default connect(
-  mapState,
-  mapDispatch
-)(More);
+export default connect(mapState, mapDispatch)(More);

--- a/client/src/redux/actions/actions.js
+++ b/client/src/redux/actions/actions.js
@@ -26,6 +26,9 @@ import {
   fetchDemographicsComorbidities,
   setDisclaimerAnswerThunk,
   resetDisclaimerAnswer,
+  setSubscribedNumber,
+  fetchSubscribedNumber,
+  unsubscribeNumber,
 } from './onboarding';
 import { deleteUserDataThunk } from './deleteUserData';
 
@@ -34,6 +37,9 @@ const actions = {
   addObservation,
   deleteObservations,
   setDisclaimerAnswerThunk,
+  setSubscribedNumber,
+  fetchSubscribedNumber,
+  unsubscribeNumber,
   selectDate,
   setToggleValue,
   setDetailData,

--- a/client/src/redux/actions/actions.js
+++ b/client/src/redux/actions/actions.js
@@ -29,6 +29,7 @@ import {
   setSubscribedNumber,
   fetchSubscribedNumber,
   unsubscribeNumber,
+  clearResponse,
 } from './onboarding';
 import { deleteUserDataThunk } from './deleteUserData';
 
@@ -40,6 +41,7 @@ const actions = {
   setSubscribedNumber,
   fetchSubscribedNumber,
   unsubscribeNumber,
+  clearResponse,
   selectDate,
   setToggleValue,
   setDetailData,

--- a/client/src/redux/actions/onboarding.js
+++ b/client/src/redux/actions/onboarding.js
@@ -9,6 +9,10 @@ export const DISCLAIMER_ANSWER = 'DISCLAIMER_ANSWER';
 
 export const RESET_ANSWER = 'RESET_ANSWER';
 
+export const SUBSCRIBED_NUMBER = 'SUBSCRIBED_NUMBER';
+
+export const UNSUBSCRIBE = 'UNSUBSCRIBE';
+
 // action creators
 export function setDisclaimerAnswer(answer) {
   return {
@@ -62,4 +66,22 @@ export const setDemographicsComorbiditiesThunk = (formData, userSession) => asyn
     .catch(err => console.error(err));
 
   dispatch(setDemographicsComorbidities(formData));
+};
+
+export const setSubscribedNumber = (userSession, phoneNumber) => async dispatch => {
+  userSession.putFile('subscribedNumber', phoneNumber).then(() => {
+    dispatch({ type: SUBSCRIBED_NUMBER, phoneNumber });
+  });
+};
+
+export const unsubscribeNumber = userSession => async dispatch => {
+  console.log('calls unsubscribe');
+  userSession.deleteFile('subscribedNumber').then(() => {
+    dispatch({ type: UNSUBSCRIBE });
+  });
+};
+
+export const fetchSubscribedNumber = userSession => async dispatch => {
+  const phoneNumber = await userSession.getFile('subscribedNumber');
+  dispatch({ type: SUBSCRIBED_NUMBER, phoneNumber });
 };

--- a/client/src/redux/reducers/onboarding.js
+++ b/client/src/redux/reducers/onboarding.js
@@ -4,6 +4,8 @@ import {
   FETCH_DEMOGRAPHICS_COMORBIDITIES,
   DISCLAIMER_ANSWER,
   RESET_ANSWER,
+  SUBSCRIBED_NUMBER,
+  UNSUBSCRIBE,
 } from '../actions/onboarding';
 
 const initialState = {
@@ -18,6 +20,7 @@ const initialState = {
     isAsthmatic: '',
   },
   disclaimerAnswer: false,
+  subscribedNumber: null,
 };
 
 const onboardingReducer = (state = initialState, action) => {
@@ -46,6 +49,16 @@ const onboardingReducer = (state = initialState, action) => {
       return {
         ...state,
         disclaimerAnswer: false,
+      };
+    case SUBSCRIBED_NUMBER:
+      return {
+        ...state,
+        subscribedNumber: action.phoneNumber,
+      };
+    case UNSUBSCRIBE:
+      return {
+        ...state,
+        subscribedNumber: null,
       };
     default:
       return state;

--- a/client/src/redux/reducers/onboarding.js
+++ b/client/src/redux/reducers/onboarding.js
@@ -4,8 +4,11 @@ import {
   FETCH_DEMOGRAPHICS_COMORBIDITIES,
   DISCLAIMER_ANSWER,
   RESET_ANSWER,
-  SUBSCRIBED_NUMBER,
+  FETCH_SUBSCRIBED_NUMBER,
+  SET_SUBSCRIBED_NUMBER,
   UNSUBSCRIBE,
+  SUBSCRIBE_ERROR,
+  CLEAR_RESPONSE,
 } from '../actions/onboarding';
 
 const initialState = {
@@ -20,7 +23,7 @@ const initialState = {
     isAsthmatic: '',
   },
   disclaimerAnswer: false,
-  subscribedNumber: null,
+  phoneNumber: { subscribedNumber: null, error: {}, success: '' },
 };
 
 const onboardingReducer = (state = initialState, action) => {
@@ -50,15 +53,50 @@ const onboardingReducer = (state = initialState, action) => {
         ...state,
         disclaimerAnswer: false,
       };
-    case SUBSCRIBED_NUMBER:
+    case FETCH_SUBSCRIBED_NUMBER:
       return {
         ...state,
-        subscribedNumber: action.phoneNumber,
+        phoneNumber: {
+          ...state.phoneNumber,
+          subscribedNumber: action.phoneNumber,
+        },
+      };
+    case SET_SUBSCRIBED_NUMBER:
+      return {
+        ...state,
+        phoneNumber: {
+          ...state.phoneNumber,
+          subscribedNumber: action.phoneNumber,
+          success: 'subscribed',
+          error: {},
+        },
       };
     case UNSUBSCRIBE:
       return {
         ...state,
-        subscribedNumber: null,
+        phoneNumber: {
+          ...state.phoneNumber,
+          subscribedNumber: null,
+          success: 'unsubscribed',
+          error: {},
+        },
+      };
+    case SUBSCRIBE_ERROR:
+      return {
+        ...state,
+        phoneNumber: {
+          ...state.phoneNumber,
+          error: action.error,
+        },
+      };
+    case CLEAR_RESPONSE:
+      return {
+        ...state,
+        phoneNumber: {
+          ...state.phoneNumber,
+          error: {},
+          success: '',
+        },
       };
     default:
       return state;


### PR DESCRIPTION
# ⚠️ __IMPORTANT: Please do not create a Pull Request without creating an issue first.__

All changes need to be discusssed before proceeding. Failure to do so may result in the pull request being rejected.

Please be sure to review our [Code of Conduct](https://github.com/COVID-19-electronic-health-system/.github/blob/master/CODE_OF_CONDUCT.md), [Contributing Guidelines](https://github.com/COVID-19-electronic-health-system/.github/blob/master/CONTRIBUTING.md), and [Support documentation](https://github.com/COVID-19-electronic-health-system/.github/blob/master/SUPPORT.md) before submitting a pull request.

-----

## Please include the issue number the pull request fixes by replacing YOUR-ISSUE-HERE in the text below.

Fixes #537 

## Summary

Adds subscribed phone number state to onboard reducer.  Also error and success state for rendering snackbar dialogs.

New flow for subscribe action, to allow conditional rendering based on whether number is subscribed: Call subscribe/unsubscribe API.  Receive response.  If call succeeds, add/remove number from gaia, then add/remove it from redux store.  Update success state string (either "subscribed" or "unsubscribed") in store, triggering rendering of proper snackbar dialog.  If response fails, update error object in store, triggering error snackbar dialog.  On dialog close, clear error/success status in store.  Render subscribe/unsubscribe buttons based on existence of subscribedNumber state in redux store.

Fetch subscribed number on app load, add to Redux store.

## Details

This update allows for conditional rendering of subscribe/unsubscribe buttons and phone number input field, allowing the user to be sure whether they have successfully subscribed previously, and at which number.  Stops user from subscribing same number twice, or unsubscribing a number that isn't subscribed.  Also decouples async api calls and error handling from UI code.  

## Test Plan (required)

I have not written tests for this code.  I'm not well versed in testing and I don't really know how to approach testing this update, and I'm a bit busy.  If anyone wants to talk through that with me, I'd be happy to look at adding tests.  

![subscribe](https://user-images.githubusercontent.com/15807680/80646851-7d69a300-8a3b-11ea-9ccf-94a868ee205d.gif)


## Final Checklist

- [X ] For CoronaTracker, did you bump the version in `package.json`?
    - Update the second decimal for a major change
    - Update the third decimal for a minor change
    - Numbers can go past 9, e.g. `1.0.9` => `1.0.10`
    - For more info, read about [Semantic Versioning](https://semver.org/)
- [ ] Did you add any new tests as necessary?
- [ X] Is your PR rebased off the most current master?
- [ ] Have you squashed all commits? _(can be done at merge)_
- [ X] Did you use `yarn` not `npm`? _(important!)_
- [ X] Did you use Material-UI wherever possible?
- [ X] Did you run `yarn lint` on the code?
- [X ] Did you run all of your most recent changes locally to make sure everything is working?
