### PR TITLE
automatically open observation detail when there is only one observation

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "corona-tracker",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "homepage": ".",
   "private": true,
   "prettier": "@blockstack/prettier-config",

--- a/client/src/components/showMeMore/Observations.jsx
+++ b/client/src/components/showMeMore/Observations.jsx
@@ -63,7 +63,8 @@ const Observations = props => {
       {(detailData.length ? detailData : observations)
         .slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage)
         .map(observation => (
-          <ExpansionPanel className={classes.expansionPanel}>
+          <ExpansionPanel className={classes.expansionPanel} 
+          defaultExpanded={observations.length === 1}>
             <ExpansionPanelSummary
               expandIcon={<ExpandMoreIcon />}
               aria-controls="observation"

--- a/client/src/components/showMeMore/Observations.jsx
+++ b/client/src/components/showMeMore/Observations.jsx
@@ -63,8 +63,7 @@ const Observations = props => {
       {(detailData.length ? detailData : observations)
         .slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage)
         .map(observation => (
-          <ExpansionPanel className={classes.expansionPanel} 
-          defaultExpanded={observations.length === 1}>
+          <ExpansionPanel className={classes.expansionPanel} defaultExpanded={detailData.length === 1}>
             <ExpansionPanelSummary
               expandIcon={<ExpandMoreIcon />}
               aria-controls="observation"


### PR DESCRIPTION
# ⚠️ __IMPORTANT: Please do not create a Pull Request without creating an Issue first.__

All changes need to be discussed before proceeding. Failure to do so may result in the pull request being rejected.

Before submitting a pull request, please be sure to review:
- Our Code of Conduct: https://github.com/COVID-19-electronic-health-system/.github/blob/master/CODE_OF_CONDUCT.md
- Our Contributing Guidelines: https://github.com/COVID-19-electronic-health-system/.github/blob/master/CONTRIBUTING.md
- Our Support documentation: https://github.com/COVID-19-electronic-health-system/.github/blob/master/SUPPORT.md

-----

## Please include the issue number the pull request fixes by replacing YOUR-ISSUE-HERE in the text below.

Fixes #697 

## Summary

When there is only one observation, the observation details will automatically open.

## Test Plan (required)


![Screen Shot 2020-05-09 at 4 44 06 PM](https://user-images.githubusercontent.com/54862890/81484568-646ba980-9214-11ea-8f59-a275c1769501.png)


## Final Checklist

- [ x] For CoronaTracker, did you bump the version in `package.json`?
    - Update the second decimal for a major change
    - Update the third decimal for a minor change
    - Numbers can go past 9, e.g. `1.0.9` => `1.0.10`
    - For more info, read about [Semantic Versioning](https://semver.org/)
- [ x] Did you add any new tests as necessary?
- [x ] Is your PR rebased off the most current master?
- [x ] Have you squashed all commits? _(can be done at merge)_
- [x ] Did you use `yarn` not `npm`? _(important!)_
- [x ] Did you use Material-UI wherever possible?
- [ x] Did you run `yarn lint` on the code?
- [x ] Did you run all of your most recent changes locally to make sure everything is working?
